### PR TITLE
feat: Implement UX Enhancements (Phase 1)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -93,21 +93,24 @@ body {
   background-color: var(--card-background-color);
   color: var(--primary-color);
   border: 1px solid var(--border-color);
+  border-bottom: 3px solid transparent; /* Reserve space for active indicator */
   min-width: 130px;
   border-radius: 10px;
   font-weight: 600;
   font-size: 1em;
   box-shadow: 0 2px 6px rgba(0,0,0,0.05);
-  transition: all 0.2s ease-out; /* Ensure all properties transition smoothly */
+  transition: all 0.2s ease-out;
   padding: 0.7em 1.1em;
   outline: none;
   cursor: pointer;
   letter-spacing: 0.5px;
   text-align: center;
+  box-sizing: border-box;
 }
 .nav-button:hover {
   background-color: color-mix(in srgb, var(--primary-color) 10%, var(--card-background-color));
-  border-color: var(--primary-color);
+  border-color: var(--primary-color); /* Hover border for top, left, right */
+  border-bottom-color: var(--primary-color); /* Hover border for bottom if not active */
   color: var(--primary-color);
   transform: translateY(-2px);
   box-shadow: 0 4px 10px color-mix(in srgb, var(--text-color) 8%, transparent);
@@ -119,22 +122,26 @@ body {
 }
 
 .nav-button-active {
-  background-color: var(--primary-color);
-  color: var(--button-text-color);
-  border-color: var(--primary-color);
+  /* background (gradient) and color are set by inline styles in App.tsx */
+  /* border-color for top/left/right is transparent via inline style in App.tsx */
+  border-bottom: 3px solid var(--secondary-color); /* Distinctive active indicator */
   box-shadow: 0 4px 12px color-mix(in srgb, var(--primary-color) 30%, transparent);
+  /* padding-bottom: calc(0.7em - 3px); /* Adjust if border was outside padding box. Not needed with border-box. */
 }
 .nav-button-active:hover {
-  background-color: color-mix(in srgb, var(--primary-color) 90%, black);
-  border-color: color-mix(in srgb, var(--primary-color) 90%, black);
-  transform: translateY(-2px); /* Keep consistent hover lift */
+  /* background-color is inline, but we can adjust other properties */
+  /* border-color for top/left/right is transparent via inline style */
+  border-bottom-color: color-mix(in srgb, var(--secondary-color) 80%, black); /* Darken active border on hover */
+  transform: translateY(-2px);
   box-shadow: 0 6px 14px color-mix(in srgb, var(--primary-color) 35%, transparent);
 }
 .nav-button-active:active {
   transform: translateY(0px);
   box-shadow: 0 2px 8px color-mix(in srgb, var(--primary-color) 30%, transparent);
+  border-bottom-color: var(--secondary-color); /* Keep active color on press */
   transition-duration: 0.05s;
 }
+
 
 /* Main Content Area */
 .app-main {
@@ -194,8 +201,6 @@ body {
 }
 .game-card:hover {
   border-color: var(--primary-color);
-  /* transform: translateY(-2px); Optional: slightly more lift */
-  /* box-shadow: 0 6px 20px rgba(0,0,0,0.08); Optional: slightly enhanced shadow */
 }
 
 
@@ -239,11 +244,11 @@ body {
 
 .game-button:hover {
   background-color: color-mix(in srgb, var(--primary-color) 85%, black);
-  transform: translateY(-2px); /* Enhanced lift */
-  box-shadow: 0 6px 14px color-mix(in srgb, var(--text-color) 18%, transparent); /* Shadow using text color for theme adaptability */
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px color-mix(in srgb, var(--text-color) 18%, transparent);
 }
 .game-button:active {
-  transform: translateY(0px); /* Pressed down from hover state */
+  transform: translateY(0px);
   box-shadow: 0 2px 5px color-mix(in srgb, var(--text-color) 15%, transparent);
   transition-duration: 0.05s;
 }
@@ -256,7 +261,7 @@ body {
 .game-button-secondary:hover {
   background-color: color-mix(in srgb, var(--primary-color) 10%, var(--card-background-color));
   border-color: color-mix(in srgb, var(--primary-color) 85%, black);
-  transform: translateY(-2px); /* Consistent lift */
+  transform: translateY(-2px);
   box-shadow: 0 6px 14px color-mix(in srgb, var(--text-color) 12%, transparent);
 }
 .game-button-secondary:active {
@@ -442,8 +447,8 @@ body {
   background-color: var(--disabled-bg-color);
   color: var(--disabled-text-color);
   cursor: not-allowed;
-  transform: none; /* Reset transform for disabled state */
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1); /* Reset shadow for disabled state */
+  transform: none;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 /* Chess Specific Grid */
@@ -473,7 +478,7 @@ body {
   padding: 0;
 }
 .chess-cell:hover:not(:disabled) {
-  transform: scale(1.05); /* Slight scale on hover for interactive cells */
+  transform: scale(1.05);
 }
 .chess-cell:active:not(:disabled) {
   transform: scale(0.98);
@@ -524,12 +529,12 @@ body {
   color: var(--button-text-color);
   font-weight: 800;
   font-size: 22px;
-  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out; /* Added for smooth animation */
+  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out;
 }
 .ludo-player-active .ludo-player-token {
   border-color: var(--secondary-color);
   box-shadow: 0 0 12px color-mix(in srgb, var(--secondary-color) 50%, transparent);
-  transform: scale(1.1); /* Active player token slightly larger */
+  transform: scale(1.1);
 }
 
 @keyframes tokenMoveHighlight {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import './App.css';
 import WinCelebration from './components/WinCelebration';
+import InstructionsModal from './components/InstructionsModal';
 
 // SVG Icon for TicTacToe
 const TicTacToeIcon = () => (
@@ -8,7 +9,6 @@ const TicTacToeIcon = () => (
     <path d="M1 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V2zM1 7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V7zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V7zM1 12a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2z"/>
   </svg>
 );
-
 
 function GamingPage() {
   const [score, setScore] = useState<number>(0);
@@ -19,6 +19,7 @@ function GamingPage() {
   const [message, setMessage] = useState<string>('');
   const [step, setStep] = useState<'color' | 'shape' | 'win'>('color');
   const [showCelebration, setShowCelebration] = useState(false);
+  const [showInstructions, setShowInstructions] = useState(false);
 
   const colorList = [
     'red', 'blue', 'green', 'yellow', 'purple', 'orange', 'pink', 'brown', 'black', 'white',
@@ -140,11 +141,28 @@ function GamingPage() {
 
   return (
     <>
-      {showCelebration && <WinCelebration onClose={() => setShowCelebration(false)} />}
+      <WinCelebration
+        isOpen={showCelebration}
+        onClose={() => setShowCelebration(false)}
+        onPlayAgain={restartGame}
+        score={score}
+        gameTitle="Shape & Color"
+      />
+      <InstructionsModal
+        isOpen={showInstructions}
+        onClose={() => setShowInstructions(false)}
+        title="🎨 Shape & Color Game - Instructions"
+      >
+        <ul>
+          <li>Identify the color of the displayed sample.</li>
+          <li>If correct, you'll then need to identify the shape that matches the sample.</li>
+          <li>Score 10 points to win the game!</li>
+        </ul>
+      </InstructionsModal>
       <div className="game-card" style={{ maxWidth: 420 }}>
         <h1><span role="img" aria-label="Palette icon">🎨</span> Shape & Color Game</h1>
         <p className="score-text">
-          Score: <b>{score}</b> / 10
+          Score: <b aria-live="polite">{score}</b> / 10
         </p>
         {step !== 'win' && (
           <button
@@ -154,6 +172,7 @@ function GamingPage() {
             <span><span role="img" aria-label="Restart icon">🔄</span> Restart</span>
           </button>
         )}
+         <button className="game-button game-button-secondary mb-2" onClick={() => setShowInstructions(true)}><span>❓ Instructions</span></button>
         {step === 'color' && (
           <>
             <div className="mt-2 mb-1" style={{ fontSize: '1.2em', fontWeight: 600, color: 'var(--text-color)' }}>
@@ -207,7 +226,7 @@ function GamingPage() {
             </button>
           </div>
         )}
-        {message && <p className="gaming-page-message" style={{ color: message.includes('win') ? 'var(--success-color)' : message.includes('Try again') || message.includes('Invalid') ? 'var(--error-color)' : 'var(--text-color)' }}>{message}</p>}
+        {message && <div role="status" aria-live="polite"><p className="gaming-page-message" style={{ color: message.includes('win') ? 'var(--success-color)' : message.includes('Try again') || message.includes('Invalid') ? 'var(--error-color)' : 'var(--text-color)' }}>{message}</p></div>}
       </div>
     </>
   );
@@ -219,6 +238,7 @@ function TicTacToe() {
   const [winner, setWinner] = useState<string | null>(null);
   const [draw, setDraw] = useState<boolean>(false);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [showInstructions, setShowInstructions] = useState(false);
 
   function calculateWinner(squares: string[]) {
     const lines = [
@@ -261,10 +281,26 @@ function TicTacToe() {
 
   return (
     <>
-      {showCelebration && winner && <WinCelebration onClose={() => setShowCelebration(false)} />}
+      <WinCelebration
+        isOpen={showCelebration && !!winner}
+        onClose={() => setShowCelebration(false)}
+        onPlayAgain={restart}
+        gameTitle="Tic-Tac-Toe"
+      />
+      <InstructionsModal
+        isOpen={showInstructions}
+        onClose={() => setShowInstructions(false)}
+        title="🏁 Tic-Tac-Toe - Instructions"
+      >
+        <ul>
+          <li>Players take turns marking a square in a 3x3 grid.</li>
+          <li>The player who first places three of their marks in a horizontal, vertical, or diagonal row wins.</li>
+          <li>If all squares are filled and no one wins, the game is a draw.</li>
+        </ul>
+      </InstructionsModal>
       <div className="game-card" style={{ maxWidth: 500 }}>
         <h2><span role="img" aria-label="Chequered flag icon">🏁</span> Tic-Tac-Toe</h2>
-        <div className="tictactoe-grid">
+        <div className="tictactoe-grid" role="grid">
           {board.map((cell, idx) => (
             <button
               key={idx}
@@ -278,12 +314,13 @@ function TicTacToe() {
             </button>
           ))}
         </div>
-        <div className="mt-1 mb-1" style={{ fontWeight: 600, fontSize: '1.3em', color: winner ? 'var(--success-color)' : draw ? 'var(--error-color)' : 'var(--text-color)', letterSpacing: 0.5 }}>
+        <div role="status" aria-live="polite" className="mt-1 mb-1" style={{ fontWeight: 600, fontSize: '1.3em', color: winner ? 'var(--success-color)' : draw ? 'var(--error-color)' : 'var(--text-color)', letterSpacing: 0.5 }}>
           {winner ? `Winner: ${winner}` : draw ? 'Draw!' : `Next: ${xIsNext ? 'X' : 'O'}`}
         </div>
         <button className="game-button game-button-secondary" onClick={restart}>
           <span><span role="img" aria-label="Restart icon">🔄</span> Restart</span>
         </button>
+        <button className="game-button game-button-secondary mt-1" onClick={() => setShowInstructions(true)}><span>❓ Instructions</span></button>
       </div>
     </>
   );
@@ -302,6 +339,7 @@ function Ludo() {
   const [displayDice, setDisplayDice] = useState<number | null>(null);
   const [justMovedPlayer, setJustMovedPlayer] = useState<number | null>(null);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [showInstructions, setShowInstructions] = useState(false);
 
   const playerColors = ['#e53935', '#43a047', '#1e88e5', '#fbc02d'];
   const playerNames = ['Red', 'Green', 'Blue', 'Yellow'];
@@ -382,9 +420,22 @@ function Ludo() {
 
   if (!gameStarted) {
     return (
+      <>
+      <InstructionsModal
+        isOpen={showInstructions}
+        onClose={() => setShowInstructions(false)}
+        title="🎲 Ludo (Mini) - Instructions"
+      >
+        <ul>
+          <li>Players take turns rolling a dice.</li>
+          <li>Move your token along the linear board according to the dice roll.</li>
+          <li>Be the first player to land exactly on step 20 to win! You must roll the exact number required.</li>
+          <li>Number of players can be selected before starting.</li>
+        </ul>
+      </InstructionsModal>
       <div className="game-card" style={{ maxWidth: 700, borderRadius: 24 }}>
         <h2><span role="img" aria-label="Dice icon">🎲</span> Ludo (Mini) - Select Players</h2>
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '1em', margin: '2em 0' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '1em', margin: '1em 0' }}>
           {[2, 3, 4].map(num => (
             <button
               key={num}
@@ -396,13 +447,32 @@ function Ludo() {
             </button>
           ))}
         </div>
+        <button className="game-button game-button-secondary" onClick={() => setShowInstructions(true)}><span>❓ Instructions</span></button>
       </div>
+      </>
     );
   }
 
   return (
     <>
-      {showCelebration && winner !== null && <WinCelebration onClose={() => setShowCelebration(false)} />}
+      <WinCelebration
+        isOpen={showCelebration && winner !== null}
+        onClose={() => setShowCelebration(false)}
+        onPlayAgain={restart}
+        gameTitle={`Ludo (${numPlayers}P)`}
+      />
+      <InstructionsModal
+        isOpen={showInstructions}
+        onClose={() => setShowInstructions(false)}
+        title="🎲 Ludo (Mini) - Instructions"
+      >
+        <ul>
+          <li>Players take turns rolling a dice.</li>
+          <li>Move your token along the linear board according to the dice roll.</li>
+          <li>Be the first player to land exactly on step 20 to win! You must roll the exact number required.</li>
+          <li>Number of players can be selected before starting.</li>
+        </ul>
+      </InstructionsModal>
       <div className="game-card" style={{ maxWidth: 700, borderRadius: 24 }}>
         <h2><span role="img" aria-label="Dice icon">🎲</span> Ludo (Mini - {numPlayers} Players)</h2>
         <div className="ludo-players mb-2">
@@ -420,20 +490,21 @@ function Ludo() {
           })}
         </div>
         <div className="text-center mt-2 mb-2">
-          <div className="ludo-board">
+          <div className="ludo-board" role="grid">
             {[...Array(4)].map((_, row) => (
-              <div key={row} className="ludo-board-row">
+              <div key={row} className="ludo-board-row" role="row">
                 {[...Array(5)].map((_, col) => {
                   const i = row * 5 + col;
                   const playerHere = positions.findIndex((p, playerIdx) => playerIdx < numPlayers && p === i);
                   return (
-                    <div key={col} className={`ludo-board-cell ${playerHere !== -1 ? 'ludo-board-cell-player' : ''}`} style={{ background: playerHere !== -1 ? playerColors[playerHere] : undefined, borderColor: playerHere !== -1 ? playerColors[playerHere] : 'var(--border-color)', boxShadow: playerHere !== -1 ? `0 1px 4px ${playerColors[playerHere]}99` : undefined }} />
+                    <div key={col} className={`ludo-board-cell ${playerHere !== -1 ? 'ludo-board-cell-player' : ''}`} style={{ background: playerHere !== -1 ? playerColors[playerHere] : undefined, borderColor: playerHere !== -1 ? playerColors[playerHere] : 'var(--border-color)', boxShadow: playerHere !== -1 ? `0 1px 4px ${playerColors[playerHere]}99` : undefined }} role="gridcell" aria-label={`Cell ${i+1}`}>
+                    </div>
                   );
                 })}
               </div>
             ))}
           </div>
-          <div className="mt-1 mb-1" style={{ fontSize: '1.1em', color: 'var(--text-color)', fontWeight: 600, minHeight: '1.5em' }}>
+          <div role="status" aria-live="polite" className="mt-1 mb-1" style={{ fontSize: '1.1em', color: 'var(--text-color)', fontWeight: 600, minHeight: '1.5em' }}>
             {winner !== null ? (
               <span style={{ color: playerColors[winner], fontWeight: 800 }}>{playerNames[winner]} wins!</span>
             ) : (
@@ -468,6 +539,7 @@ function Ludo() {
           >
             <span><span role="img" aria-label="Settings icon">⚙️</span> Change Players</span>
           </button>
+           <button className="game-button game-button-secondary mt-1" onClick={() => setShowInstructions(true)}><span>❓ Instructions</span></button>
         </div>
       </div>
     </>
@@ -511,6 +583,7 @@ function Sudoku() {
   const [message, setMessage] = useState<string>('');
   const [completed, setCompleted] = useState<boolean>(false);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [showInstructions, setShowInstructions] = useState(false);
 
   const getCurrentInitialBoard = () => sudokuBoards[difficulty];
 
@@ -559,7 +632,24 @@ function Sudoku() {
 
   return (
     <>
-      {showCelebration && completed && <WinCelebration onClose={() => setShowCelebration(false)} />}
+      <WinCelebration
+        isOpen={showCelebration && completed}
+        onClose={() => setShowCelebration(false)}
+        onPlayAgain={restart}
+        gameTitle="Sudoku (4x4)"
+      />
+      <InstructionsModal
+        isOpen={showInstructions}
+        onClose={() => setShowInstructions(false)}
+        title="🔢 Sudoku (4x4) - Instructions"
+      >
+        <ul>
+          <li>Fill the 4x4 grid.</li>
+          <li>Each row, each column, and each of the four 2x2 subgrids must contain all digits from 1 to 4 without repetition.</li>
+          <li>Select an empty cell, then click a number button (1-4) to place it.</li>
+          <li>Pre-filled cells cannot be changed. Choose your difficulty!</li>
+        </ul>
+      </InstructionsModal>
       <div className="game-card" style={{ maxWidth: 420, borderRadius: 20 }}>
         <h2><span role="img" aria-label="Numeric input icon">🔢</span> Sudoku (4x4)</h2>
         <div className="sudoku-difficulty-selector mb-2" style={{ display: 'flex', justifyContent: 'center', gap: '0.5em' }}>
@@ -574,7 +664,7 @@ function Sudoku() {
             </button>
           ))}
         </div>
-        <div className="sudoku-grid">
+        <div className="sudoku-grid" role="grid">
           {board.map((row: number[], rIdx: number) =>
             row.map((cell: number, cIdx: number) => (
               <button
@@ -605,12 +695,15 @@ function Sudoku() {
             </button>
           ))}
         </div>
-        <div className="mt-1 mb-1" style={{ fontWeight: 600, fontSize: '1.1em', color: completed ? 'var(--success-color)' : 'var(--text-color)', letterSpacing: 0.5 }}>
+        <div role="status" aria-live="polite" className="mt-1 mb-1" style={{ fontWeight: 600, fontSize: '1.1em', color: completed ? 'var(--success-color)' : 'var(--text-color)', letterSpacing: 0.5 }}>
           {message}
         </div>
-        <button className="game-button game-button-secondary" onClick={restart}>
-          <span><span role="img" aria-label="Restart icon">🔄</span> Restart</span>
-        </button>
+        <div style={{display: 'flex', gap: '1em', justifyContent: 'center', width: '100%'}}>
+          <button className="game-button game-button-secondary" onClick={restart}>
+            <span><span role="img" aria-label="Restart icon">🔄</span> Restart</span>
+          </button>
+          <button className="game-button game-button-secondary" onClick={() => setShowInstructions(true)}><span>❓ Instructions</span></button>
+        </div>
       </div>
     </>
   );
@@ -631,6 +724,7 @@ function Chess() {
   const [message, setMessage] = useState<string>('');
   const [winner, setWinner] = useState<string | null>(null);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [showInstructions, setShowInstructions] = useState(false);
 
   function isOwnPiece(piece: string) {
     return piece && piece[0] === turn;
@@ -731,10 +825,28 @@ function Chess() {
 
   return (
     <>
-      {showCelebration && winner && <WinCelebration onClose={() => setShowCelebration(false)} />}
+      <WinCelebration
+        isOpen={showCelebration && !!winner}
+        onClose={() => setShowCelebration(false)}
+        onPlayAgain={restart}
+        gameTitle="Chess (Mini 4x4)"
+      />
+      <InstructionsModal
+        isOpen={showInstructions}
+        onClose={() => setShowInstructions(false)}
+        title="♟️ Chess (Mini 4x4) - Instructions"
+      >
+        <ul>
+          <li>This is a simplified 4x4 version of Chess.</li>
+          <li>Pawns (♙♟️) move one step forward. They capture one step diagonally forward.</li>
+          <li>Rooks (♖♜) move any number of clear squares horizontally or vertically.</li>
+          <li>Kings (♔♚) move one square in any direction.</li>
+          <li>The goal is to capture the opponent's King.</li>
+        </ul>
+      </InstructionsModal>
       <div className="game-card" style={{ maxWidth: 420, borderRadius: 20 }}>
         <h2><span role="img" aria-label="Chess pawn icon">♟️</span> Chess (Mini 4x4)</h2>
-        <div className="chess-grid">
+        <div className="chess-grid" role="grid">
           {board.map((row, rIdx) =>
             row.map((cell, cIdx) => {
               const isSel = selected && selected[0] === rIdx && selected[1] === cIdx;
@@ -750,6 +862,7 @@ function Chess() {
                   onClick={() => handleCellClick(rIdx, cIdx)}
                   aria-label={`Chess cell ${rIdx + 1},${cIdx + 1}`}
                   disabled={!!winner}
+                  // role="gridcell"
                 >
                   {renderPiece(cell)}
                 </button>
@@ -757,12 +870,15 @@ function Chess() {
             })
           )}
         </div>
-        <div className="mt-1 mb-1" style={{ fontWeight: 600, fontSize: '1.1em', color: winner ? 'var(--success-color)' : 'var(--text-color)', letterSpacing: 0.5 }}>
+        <div role="status" aria-live="polite" className="mt-1 mb-1" style={{ fontWeight: 600, fontSize: '1.1em', color: winner ? 'var(--success-color)' : 'var(--text-color)', letterSpacing: 0.5 }}>
           {winner ? `${winner} wins!` : message || `${turn === 'w' ? 'White' : 'Black'}'s turn`}
         </div>
-        <button className="game-button game-button-secondary" onClick={restart}>
-          <span><span role="img" aria-label="Restart icon">🔄</span> Restart</span>
-        </button>
+        <div style={{display: 'flex', gap: '1em', justifyContent: 'center', width: '100%'}}>
+          <button className="game-button game-button-secondary" onClick={restart}>
+            <span><span role="img" aria-label="Restart icon">🔄</span> Restart</span>
+          </button>
+          <button className="game-button game-button-secondary" onClick={() => setShowInstructions(true)}><span>❓ Instructions</span></button>
+        </div>
       </div>
     </>
   );
@@ -802,8 +918,8 @@ function App() {
             fontSize: '0.9em',
             minWidth: 'auto'
         }}
-        aria-label={`Switch to ${theme === 'light' ? 'Dark' : 'Light'} Mode`}
-        title={`Switch to ${theme === 'light' ? 'Dark' : 'Light'} Mode`}
+        aria-label={theme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode'}
+        title={theme === 'light' ? 'Switch to Dark Mode' : 'Switch to Light Mode'}
         >
           <span>{theme === 'light' ? '🌙' : '☀️'}</span>
         </button>

--- a/src/components/InstructionsModal.css
+++ b/src/components/InstructionsModal.css
@@ -1,0 +1,88 @@
+/* Keyframes (can be shared or defined per component style) */
+@keyframes fadeInOverlay {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes popInContent {
+  from { transform: scale(0.85); opacity: 0; } /* Start from a slightly larger scale for smoother pop */
+  to { transform: scale(1); opacity: 1; }
+}
+
+.instructions-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.65); /* Slightly darker overlay */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+  animation: fadeInOverlay 0.25s ease-out forwards;
+}
+
+.instructions-modal-content {
+  background: var(--card-background-color);
+  color: var(--text-color);
+  padding: 25px; /* Increased padding */
+  border-radius: 12px; /* Consistent with game-card */
+  width: 90%;
+  max-width: 550px; /* Slightly wider for more content */
+  box-shadow: 0 8px 25px rgba(0,0,0,0.25); /* Enhanced shadow */
+  transform: scale(0.9); /* Initial state for animation */
+  animation: popInContent 0.25s 0.05s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards; /* Smoother pop with custom bezier */
+}
+
+.instructions-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 12px; /* Adjusted padding */
+  margin-bottom: 18px; /* Adjusted margin */
+}
+
+.instructions-modal-header h2 {
+  margin: 0;
+  font-size: 1.6em; /* Adjusted size */
+  color: var(--primary-color);
+  font-weight: 700; /* Ensure consistent header weight */
+}
+
+.instructions-modal-close-btn {
+  background: none;
+  border: none;
+  font-size: 2.2em; /* Larger close button */
+  cursor: pointer;
+  color: var(--subtle-text-color); /* Subtle color */
+  padding: 0 8px; /* Adjust padding for better click area */
+  line-height: 1; /* Ensure consistent vertical alignment */
+  transition: color 0.2s ease-out;
+}
+.instructions-modal-close-btn:hover {
+  color: var(--secondary-color); /* Use secondary color for hover */
+}
+
+.instructions-modal-body {
+  max-height: 65vh; /* Slightly increased max-height */
+  overflow-y: auto;
+  line-height: 1.65; /* Improved line height */
+  padding-right: 5px; /* Add a little padding if scrollbar appears */
+}
+.instructions-modal-body ul {
+  padding-left: 20px;
+  margin-top: 0; /* Remove default top margin from ul */
+  margin-bottom: 0;
+}
+.instructions-modal-body li {
+  margin-bottom: 0.6em; /* Slightly more space between list items */
+}
+.instructions-modal-body p {
+    margin-top: 0;
+    margin-bottom: 1em;
+}
+.instructions-modal-body p:last-child {
+    margin-bottom: 0;
+}

--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import './InstructionsModal.css';
+
+interface InstructionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}
+
+const InstructionsModal: React.FC<InstructionsModalProps> = ({ isOpen, onClose, title, children }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      window.addEventListener('keydown', handleEsc);
+      // Future enhancement: focus management
+    }
+    return () => {
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, [isOpen, onClose]);
+
+  // Generate a more unique ID for ARIA
+  const modalTitleId = `instructions-title-${title.replace(/\s+/g, '-').toLowerCase().replace(/[^a-z0-9-]/g, '') || 'modal'}-${Math.random().toString(36).substring(2, 9)}`;
+
+
+  return (
+    <div
+      className="instructions-modal-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={modalTitleId}
+    >
+      <div className="instructions-modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="instructions-modal-header">
+          <h2 id={modalTitleId}>{title}</h2>
+          <button onClick={onClose} className="instructions-modal-close-btn" aria-label="Close instructions">&times;</button>
+        </div>
+        <div className="instructions-modal-body">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InstructionsModal;

--- a/src/components/WinCelebration.css
+++ b/src/components/WinCelebration.css
@@ -1,42 +1,3 @@
-/* src/components/WinCelebration.css */
-.win-celebration-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: rgba(0, 0, 0, 0.75); /* Darker overlay for better contrast */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 10000; /* Very high z-index to be on top of everything */
-  cursor: pointer;
-  animation: fadeInOverlay 0.3s ease-out;
-}
-
-.win-celebration-content {
-  background-color: var(--card-background-color); /* Use theme variable */
-  padding: 30px 40px; /* Adjusted padding */
-  border-radius: 12px; /* Consistent with game-card */
-  text-align: center;
-  color: var(--text-color); /* Use theme variable */
-  box-shadow: 0 8px 25px rgba(0,0,0,0.15); /* Adjusted shadow */
-  transform: scale(0.8); /* Initial state for pop-in */
-  animation: popInContent 0.3s 0.1s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards; /* Smoother pop-in */
-}
-
-.win-celebration-content h1 {
-  font-size: 2.8em; /* Adjusted size */
-  color: var(--primary-color); /* Use theme variable */
-  margin-top: 0; /* Reset margin */
-  margin-bottom: 0.5em;
-}
-
-.win-celebration-content p {
-  font-size: 1.1em;
-  margin-bottom: 0.5em;
-}
-
 /* Keyframes for animations */
 @keyframes fadeInOverlay {
   from { opacity: 0; }
@@ -44,42 +5,168 @@
 }
 
 @keyframes popInContent {
-  from { transform: scale(0.8); opacity: 0; }
+  from { transform: scale(0.85); opacity: 0; }
   to { transform: scale(1); opacity: 1; }
 }
 
-/* Responsive adjustments for WinCelebration */
-@media (max-width: 768px) {
-  .win-celebration-content {
-    padding: 25px 30px; /* Reduce padding */
-    /* max-width: 80vw; */ /* Ensure it's not too wide */
-  }
-  .win-celebration-content h1 {
-    font-size: 2.2em; /* Reduce font size */
-  }
-  .win-celebration-content p {
-    font-size: 1em;
-  }
-  .win-celebration-content p:last-child { /* Smaller text for dismiss message */
-    font-size: 0.7em;
-    margin-top: 15px; /* Add some space for the smaller text */
-  }
+/* Shared styles for modal overlays */
+.instructions-modal-overlay,
+.win-celebration-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.70); /* Adjusted alpha for consistency */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10000;
+  animation: fadeInOverlay 0.25s ease-out forwards;
+  cursor: pointer; /* Allow closing by clicking overlay */
 }
 
+/* Shared styles for modal content boxes */
+.instructions-modal-content,
+.win-celebration-content {
+  background: var(--card-background-color);
+  color: var(--text-color);
+  padding: 25px 30px;
+  border-radius: 12px;
+  width: 90%;
+  box-shadow: 0 8px 25px rgba(0,0,0,0.25);
+  transform: scale(0.9);
+  animation: popInContent 0.25s 0.05s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
+  cursor: default;
+  text-align: center; /* Center content for win celebration */
+}
+
+/* Specific to Instructions Modal */
+.instructions-modal-content {
+  max-width: 550px;
+  text-align: left; /* Instructions are usually better left-aligned */
+}
+.instructions-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 12px;
+  margin-bottom: 18px;
+}
+.instructions-modal-header h2 {
+  margin: 0;
+  font-size: 1.6em;
+  color: var(--primary-color);
+  font-weight: 700;
+}
+.instructions-modal-close-btn {
+  background: none;
+  border: none;
+  font-size: 2.2em;
+  cursor: pointer;
+  color: var(--subtle-text-color);
+  padding: 0 8px;
+  line-height: 1;
+  transition: color 0.2s ease-out;
+}
+.instructions-modal-close-btn:hover {
+  color: var(--secondary-color);
+}
+.instructions-modal-body {
+  max-height: 65vh;
+  overflow-y: auto;
+  line-height: 1.65;
+  padding-right: 5px; /* For scrollbar */
+}
+.instructions-modal-body ul {
+  padding-left: 20px;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.instructions-modal-body li {
+  margin-bottom: 0.6em;
+}
+.instructions-modal-body p {
+    margin-top: 0;
+    margin-bottom: 1em;
+}
+.instructions-modal-body p:last-child {
+    margin-bottom: 0;
+}
+
+/* Specific to Win Celebration Modal */
+.win-celebration-content {
+  max-width: 480px; /* Slightly narrower than instructions */
+}
+.win-celebration-icon {
+  font-size: 4em;
+  display: block;
+  margin-bottom: 0.2em;
+  animation: popInContent 0.5s 0.1s ease-out forwards; /* Can reuse or define new */
+}
+.win-celebration-content h1 {
+  font-size: 2.2em;
+  color: var(--primary-color);
+  margin-top: 0.2em;
+  margin-bottom: 0.4em;
+}
+.win-celebration-score {
+  font-size: 1.4em;
+  color: var(--secondary-color);
+  font-weight: 600;
+  margin-top: 0;
+  margin-bottom: 0.5em;
+}
+.win-celebration-content p { /* General paragraph in win celebration */
+  font-size: 1.1em;
+  margin-bottom: 0.8em;
+}
+.win-celebration-content p:last-child { /* Specifically for the "Congratulations!" if it's last */
+    margin-bottom: 0;
+}
+
+.win-celebration-actions {
+  margin-top: 1.8em;
+  display: flex;
+  gap: 1em;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap; /* Allow wrapping if buttons are too wide */
+}
+.win-celebration-actions .game-button {
+  min-width: 170px; /* Adjusted min-width */
+  font-size: 1em;
+}
+
+/* Responsive adjustments for Win Celebration */
 @media (max-width: 480px) {
   .win-celebration-content {
-    padding: 20px 15px; /* Further reduce padding */
-    width: 85vw;
-    max-width: 320px; /* Max width for very small screens */
+    padding: 20px 15px;
+    width: 90vw;
+    max-width: 320px;
   }
   .win-celebration-content h1 {
-    font-size: 1.8em; /* Further reduce font size */
+    font-size: 1.8em;
   }
-  .win-celebration-content p {
-    font-size: 0.9em;
+  .win-celebration-icon {
+    font-size: 3em;
   }
-   .win-celebration-content p:last-child {
-    font-size: 0.65em;
-    margin-top: 10px;
+  .win-celebration-score {
+    font-size: 1.2em;
+  }
+   .win-celebration-actions {
+    flex-direction: column; /* Stack buttons on small screens */
+    width: 100%;
+    gap: 0.8em;
+  }
+  .win-celebration-actions .game-button {
+    width: 100%;
+    min-width: unset;
+    font-size: 1em;
+    margin-bottom: 0.5em;
+  }
+   .win-celebration-actions .game-button:last-child {
+    margin-bottom: 0;
   }
 }

--- a/src/components/WinCelebration.tsx
+++ b/src/components/WinCelebration.tsx
@@ -2,27 +2,74 @@ import React, { useEffect } from 'react';
 import './WinCelebration.css';
 
 interface WinCelebrationProps {
+  isOpen: boolean;
   onClose: () => void;
+  onPlayAgain: () => void;
+  score?: number;
+  gameTitle?: string;
 }
 
-const WinCelebration: React.FC<WinCelebrationProps> = ({ onClose }) => {
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      onClose();
-    }, 5000); // Auto close after 5 seconds
+const WinCelebration: React.FC<WinCelebrationProps> = ({
+  isOpen,
+  onClose,
+  onPlayAgain,
+  score,
+  gameTitle
+}) => {
 
-    // Cleanup timer on component unmount
-    return () => clearTimeout(timer);
-  }, [onClose]);
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    if (isOpen) {
+      window.addEventListener('keydown', handleEsc);
+      // Future enhancement: focus management, e.g., focus the "Play Again" button
+    }
+    return () => {
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handlePlayAgainClick = () => {
+    onPlayAgain();
+  };
+
+  const handleBackToHubClick = () => {
+    onClose();
+  };
+
+  const modalTitleText = gameTitle ? `You Beat ${gameTitle}!` : '🎉 You Won! 🎉';
+  // Generate a more unique ID for ARIA
+  const titleId = `win-celebration-title-${(gameTitle || 'general-win').replace(/\s+/g, '-').toLowerCase().replace(/[^a-z0-9-]/g, '') || 'modal'}-${Math.random().toString(36).substring(2, 9)}`;
+
 
   return (
-    <div className="win-celebration-overlay" onClick={onClose}>
-      <div className="win-celebration-content">
-        <h1>🎉 You Won! 🎉</h1>
-        {/* Placeholder for GIF/animation - using text for now */}
-        <p style={{ fontSize: '2em', margin: '20px 0' }}>🎆 FIREWORKS! 🎆</p>
+    <div
+      className="win-celebration-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <div className="win-celebration-content" onClick={(e) => e.stopPropagation()}>
+        <span className="win-celebration-icon" role="img" aria-label="Trophy">🏆</span>
+        <h1 id={titleId}>{modalTitleText}</h1>
+        {score !== undefined && <p className="win-celebration-score">Final Score: {score}</p>}
         <p>Congratulations!</p>
-        <p style={{ fontSize: '0.8em', marginTop: '20px', color: 'var(--subtle-text-color)' }}>(Click to dismiss or wait 5 seconds)</p>
+        <div className="win-celebration-actions">
+          <button className="game-button game-button-primary" onClick={handlePlayAgainClick}>
+            <span><span role="img" aria-label="Restart icon">🔄</span> Play Again</span>
+          </button>
+          <button className="game-button game-button-secondary" onClick={handleBackToHubClick}>
+            <span><span role="img" aria-label="Controller icon">🎮</span> Back to Hub</span>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -74,7 +74,7 @@ h2 {
   font-size: 2em;
 }
 
-button { /* Default button styling - will be overridden by .game-button etc. but good for consistency */
+button {
   border-radius: 8px;
   border: 1px solid transparent;
   padding: 0.6em 1.2em;


### PR DESCRIPTION
This commit introduces several user experience improvements:

1.  **Game Instructions Modals:**
    - Added a reusable `InstructionsModal.tsx` component.
    - Integrated "Instructions" buttons (with ❓ icon) and modals with specific instructions for all five games (`GamingPage`, `TicTacToe`, `Ludo`, `Sudoku`, `Chess`).
    - Modals are dismissible via Escape key, overlay click, or close button.

2.  **Refined Win Celebration Screen:**
    - Enhanced `WinCelebration.tsx` to be more informative and interactive.
    - Displays a prominent trophy icon (🏆) and the game title (e.g., "You Beat Tic-Tac-Toe!").
    - Conditionally displays the final score for games that have one (e.g., Shape & Color Game).
    - Added "Play Again" (🔄) and "Back to Hub" (🎮) buttons for clearer post-win actions.
    - Improved CSS for better layout and responsiveness of the win modal.

3.  **Initial Accessibility (A11y) Fixes:**
    - Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to `InstructionsModal.tsx` and `WinCelebration.tsx` for better screen reader support.
    - Implemented ARIA live regions (`role="status"`, `aria-live="polite"`) for dynamic game content such as game messages, score updates, and turn indicators across all relevant games.
    - Assigned `role="grid"` to main game board containers (TicTacToe, Sudoku, Chess, Ludo) and appropriate roles/labels for Ludo board cells.
    - Verified ARIA labels for icon-only buttons like the theme switcher.

4.  **Improved Active Game Navigation UX:**
    - Enhanced the visual distinction of the active game button in the main navigation header.
    - The active button now has a prominent bottom border using `var(--secondary-color)`, in addition to its existing gradient background, making it easier to identify the current game.
    - Non-active navigation buttons reserve space for this border to prevent layout shifts.