### PR TITLE
feat: Add Memory, Hangman, and Minesweeper games

### DIFF
--- a/src/components/HangmanGame.tests.md
+++ b/src/components/HangmanGame.tests.md
@@ -1,0 +1,143 @@
+```markdown
+# Hangman Game Unit Tests
+
+This document outlines unit tests for the `HangmanGame` component, which is part of `src/App.tsx`. These tests aim to verify the core game logic and user interactions. We assume a testing environment like React Testing Library with Jest or Vitest.
+
+## Test Suites and Cases
+
+### 1. Initial State
+
+*   **Test Case 1.1: Word Initialization and Display**
+    *   **Description**: Verifies that a word is selected upon game initialization and displayed correctly as underscores.
+    *   **Assertions**:
+        *   Check that `selectedWord` state has a value from the `wordList`.
+        *   Verify the displayed word consists of only underscores, matching the length of `selectedWord`. For example, if "REACT" is chosen, `_ _ _ _ _` should be displayed.
+
+*   **Test Case 1.2: Hangman Figure Initial State**
+    *   **Description**: Ensures the Hangman SVG figure is in its initial state (e.g., only the gallows, no body parts drawn).
+    *   **Assertions**:
+        *   Check that the number of drawn Hangman parts (e.g., `circle`, `line` elements corresponding to head, body, etc., beyond the gallows) is 0.
+        *   Verify the `incorrectGuesses` state is 0.
+
+*   **Test Case 1.3: Guessed Letters Initialization**
+    *   **Description**: Confirms that no letters are marked as guessed at the start.
+    *   **Assertions**:
+        *   Verify the `guessedLetters` state array is empty.
+        *   All buttons on the on-screen keyboard should be enabled and not styled as "guessed".
+
+### 2. Letter Guessing Logic
+
+*   **Test Case 2.1: Correct Letter Guess (Input Field & Keyboard)**
+    *   **Description**: Tests functionality when a correct letter is guessed, both via input field and on-screen keyboard.
+    *   **Actions**:
+        *   Identify a letter present in the `selectedWord` (e.g., 'A' if word is "REACT").
+        *   *Scenario 1 (Input):* Simulate typing the letter into the input field and submitting the form.
+        *   *Scenario 2 (Keyboard):* Simulate clicking the corresponding letter button on the on-screen keyboard.
+    *   **Assertions (for both scenarios)**:
+        *   The letter is revealed in the displayed word (e.g., `_ A _ _ _` if 'A' was guessed for "REACT").
+        *   The guessed letter is added to the `guessedLetters` state.
+        *   The on-screen keyboard button for the guessed letter should be styled as correct (e.g., green background) and disabled.
+        *   The `incorrectGuesses` state remains unchanged.
+        *   The Hangman SVG figure remains unchanged.
+
+*   **Test Case 2.2: Incorrect Letter Guess (Input Field & Keyboard)**
+    *   **Description**: Tests functionality when an incorrect letter is guessed.
+    *   **Actions**:
+        *   Identify a letter *not* present in the `selectedWord` (e.g., 'Z' if word is "REACT").
+        *   *Scenario 1 (Input):* Simulate typing 'Z' into the input field and submitting.
+        *   *Scenario 2 (Keyboard):* Simulate clicking 'Z' on the on-screen keyboard.
+    *   **Assertions (for both scenarios)**:
+        *   The displayed word (underscores) remains unchanged.
+        *   The guessed letter 'Z' is added to the `guessedLetters` state.
+        *   The on-screen keyboard button for 'Z' should be styled as incorrect (e.g., red background) and disabled.
+        *   The `incorrectGuesses` state increments by 1.
+        *   One more part of the Hangman SVG figure is rendered.
+
+*   **Test Case 2.3: Repeated Letter Guess**
+    *   **Description**: Ensures that guessing the same letter multiple times (whether it was initially correct or incorrect) has no further effect.
+    *   **Actions**:
+        *   Guess a letter (e.g., 'A'). Note the game state (displayed word, incorrect guesses, Hangman figure).
+        *   Guess the same letter 'A' again.
+    *   **Assertions**:
+        *   The game state (displayed word, `incorrectGuesses` count, Hangman figure, `guessedLetters` array) should be identical to the state after the first guess of 'A'.
+        *   The input field should be cleared.
+
+*   **Test Case 2.4: Invalid Input Handling (e.g., numbers, multiple characters)**
+    *   **Description**: Tests how the input field handles invalid entries.
+    *   **Actions**:
+        *   Simulate typing "5" into the input field and submitting.
+        *   Simulate typing "AB" into the input field and submitting.
+        *   Simulate submitting an empty input field.
+    *   **Assertions**:
+        *   The `guessedLetters` state should not change.
+        *   The `incorrectGuesses` state should not change.
+        *   The Hangman figure should not change.
+        *   The input field should be cleared or reject the input.
+        *   No error should be thrown.
+
+*   **Test Case 2.5: Case Insensitive Guess**
+    *   **Description**: Ensures guesses are case-insensitive (e.g., 'a' is treated as 'A').
+    *   **Actions**:
+        *   Assume `selectedWord` is "REACT".
+        *   Simulate typing 'r' (lowercase) into the input field and submitting.
+    *   **Assertions**:
+        *   The letter 'R' should be revealed in the display.
+        *   'R' (uppercase) should be in `guessedLetters`.
+
+### 3. Win Condition
+
+*   **Test Case 3.1: Guessing All Letters Correctly**
+    *   **Description**: Verifies that the game correctly identifies a win when all letters of the `selectedWord` are guessed.
+    *   **Actions**:
+        *   For the `selectedWord`, simulate guessing each unique letter correctly.
+    *   **Assertions**:
+        *   The full word should be displayed (no underscores).
+        *   The `WinCelebration` component should be visible/rendered (or `gameStatus` is 'won' and `showWinCelebration` is true).
+        *   A success message should be displayed.
+        *   All letter input (input field and on-screen keyboard) should be disabled.
+
+### 4. Loss Condition
+
+*   **Test Case 4.1: Reaching Maximum Incorrect Guesses**
+    *   **Description**: Verifies that the game correctly identifies a loss when `maxIncorrectGuesses` is reached.
+    *   **Actions**:
+        *   Simulate making `maxIncorrectGuesses` number of incorrect letter guesses.
+    *   **Assertions**:
+        *   The Hangman SVG figure should be fully drawn (all 6 parts visible).
+        *   The `gameStatus` state should be 'lost'.
+        *   A "Game Over" message should be displayed.
+        *   The `selectedWord` should be revealed to the player.
+        *   All letter input (input field and on-screen keyboard) should be disabled.
+
+### 5. Restart Game Logic
+
+*   **Test Case 5.1: Restart Button Functionality**
+    *   **Description**: Checks that clicking the "Restart Game" / "New Word" button resets the game to a clean initial state with a new word.
+    *   **Actions**:
+        *   Make a few guesses (some correct, some incorrect).
+        *   Note the `selectedWord`, `guessedLetters`, `incorrectGuesses`, and displayed word.
+        *   Simulate clicking the "Restart Game" button.
+    *   **Assertions**:
+        *   A new `selectedWord` is chosen (should be different from the previous one with high probability, or ensure `initializeGame` logic is re-run).
+        *   The displayed word is reset to all underscores, matching the new word's length.
+        *   `guessedLetters` array is empty.
+        *   `incorrectGuesses` count is 0.
+        *   The Hangman SVG figure is reset to its initial state.
+        *   `gameStatus` is 'playing'.
+        *   `WinCelebration` (if previously visible) is hidden.
+        *   Input field is clear and enabled. On-screen keyboard is reset.
+
+### 6. Instructions Modal
+
+*   **Test Case 6.1: Toggle Instructions Modal Visibility**
+    *   **Description**: Verifies that the "Instructions" button correctly shows and hides the instructions modal.
+    *   **Actions**:
+        *   Render the `HangmanGame`.
+        *   Simulate clicking the "Instructions" button.
+    *   **Assertions**:
+        *   The `InstructionsModal` component becomes visible (`showInstructions` state is true).
+    *   **Actions (Part 2)**:
+        *   Simulate clicking the close mechanism of the modal (or the "Instructions" button again if it's a toggle – though typically it's a one-way open, and modal has its own close).
+    *   **Assertions (Part 2)**:
+        *   The `InstructionsModal` is hidden (`showInstructions` state is false).
+```

--- a/src/components/MemoryGame.tests.md
+++ b/src/components/MemoryGame.tests.md
@@ -1,0 +1,165 @@
+```markdown
+# Memory Game Unit Tests
+
+This document outlines the unit tests for the `MemoryGame` component located in `src/App.tsx`. These tests are designed to ensure the core functionality of the game operates as expected. We'll assume the use of a testing library like React Testing Library with Jest or Vitest.
+
+## Test Suites and Cases
+
+### 1. Initial State
+
+*   **Test Case 1.1: Grid Rendering**
+    *   **Description**: Verifies that the game grid renders with the correct total number of cards. For a 4x4 grid based on 8 unique card values, this means 16 cards.
+    *   **Assertions**:
+        *   Check that 16 card elements are present in the rendered output.
+        *   Each card element should initially display its "hidden" state (e.g., shows '?' or has a specific class for being face-down).
+
+*   **Test Case 1.2: All Cards Initially Hidden**
+    *   **Description**: Ensures all cards are face-down (not revealing their actual value) when the game starts.
+    *   **Assertions**:
+        *   Iterate through all rendered card elements.
+        *   Verify that each card does not display its actual value (e.g., 'A', 'B').
+        *   Verify that each card has the appropriate ARIA attributes for a hidden card (e.g., `aria-label="Hidden card X"`).
+
+*   **Test Case 1.3: Moves Counter Initialization**
+    *   **Description**: Checks that the moves counter is initialized to 0.
+    *   **Assertions**:
+        *   Find the moves counter display element.
+        *   Verify its text content is "Moves: 0" or similar.
+
+*   **Test Case 1.4: Matched Pairs Initialization**
+    *   **Description**: Checks that the count of matched pairs is initialized to 0.
+    *   **Assertions**:
+        *   (Internal state check if not displayed) Verify the `matchedPairs` state is 0.
+
+### 2. Card Flipping Logic
+
+*   **Test Case 2.1: Clicking a Single Hidden Card**
+    *   **Description**: Tests that clicking a hidden card flips it and reveals its value.
+    *   **Actions**:
+        *   Render the `MemoryGame` component.
+        *   Simulate a click on one of the hidden card elements.
+    *   **Assertions**:
+        *   Verify the clicked card now displays its actual value (e.g., 'A').
+        *   Verify the card's state/class changes to "flipped".
+        *   Verify other cards remain hidden.
+        *   Moves counter should remain unchanged (as a full move involves two cards).
+
+*   **Test Case 2.2: Clicking Two Different Hidden Cards**
+    *   **Description**: Tests that clicking two different hidden cards flips them both.
+    *   **Actions**:
+        *   Render the `MemoryGame` component.
+        *   Simulate a click on a first hidden card.
+        *   Simulate a click on a second, different hidden card.
+    *   **Assertions**:
+        *   Verify both clicked cards now display their values.
+        *   Verify both cards have a "flipped" state/class.
+
+*   **Test Case 2.3: Clicking an Already Flipped Card**
+    *   **Description**: Ensures clicking an already flipped card (that isn't part of a completed match evaluation) does not change its state or count as a move.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Click one card to flip it.
+        *   Click the same card again.
+    *   **Assertions**:
+        *   The card remains flipped, showing its value.
+        *   No change in moves count or game state.
+
+*   **Test Case 2.4: Clicking a Matched Card**
+    *   **Description**: Ensures clicking a card that is already part of a successful match does nothing.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Simulate gameplay to match a pair of cards (e.g., click card 'A' at index 0, then card 'A' at index 5).
+        *   Wait for match confirmation.
+        *   Simulate a click on one of the matched cards.
+    *   **Assertions**:
+        *   The card remains matched and visible.
+        *   No change in moves count or game state.
+
+### 3. Matching Pair Logic
+
+*   **Test Case 3.1: Two Flipped Cards Form a Match**
+    *   **Description**: Verifies that if two flipped cards have the same value, they are marked as matched and remain visible.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Identify two cards with the same value (e.g., find two 'A's by inspecting initial state or pre-setting shuffle).
+        *   Simulate clicking the first card.
+        *   Simulate clicking the second card (the matching one).
+    *   **Assertions**:
+        *   Both cards should remain visible and display their value.
+        *   Both cards should have a "matched" state/class.
+        *   The internal `matchedPairs` count should increment by 1.
+        *   The `moves` counter should increment by 1.
+
+### 4. Non-Matching Pair Logic
+
+*   **Test Case 4.1: Two Flipped Cards Do Not Match**
+    *   **Description**: Verifies that if two flipped cards have different values, they flip back to their hidden state after a delay.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Identify two cards with different values (e.g., card 'A' and card 'B').
+        *   Simulate clicking the first card.
+        *   Simulate clicking the second card (the non-matching one).
+    *   **Assertions (after timeout)**:
+        *   Use `jest.advanceTimersByTime()` or `waitFor` from React Testing Library to handle the timeout.
+        *   Both cards should revert to their hidden state (not displaying their value, showing '?').
+        *   Neither card should have the "matched" state/class.
+        *   The `moves` counter should increment by 1.
+        *   The `matchedPairs` count should remain unchanged.
+
+### 5. Win Condition
+
+*   **Test Case 5.1: Game Win Trigger**
+    *   **Description**: Ensures the game correctly identifies a win when all pairs have been matched and triggers the win celebration.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Simulate gameplay to match all pairs of cards. This might involve programmatically setting card states or a long sequence of clicks.
+    *   **Assertions**:
+        *   Verify the `WinCelebration` component becomes visible/is rendered.
+        *   Verify the `showCelebration` state is true.
+        *   The game board might become non-interactive (all cards disabled).
+
+### 6. Restart Game Logic
+
+*   **Test Case 6.1: Restart Button Functionality**
+    *   **Description**: Checks if clicking the "Restart" button resets the game to its initial state.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Simulate a few moves (e.g., flip some cards, make a match or two).
+        *   Simulate a click on the "Restart" button.
+    *   **Assertions**:
+        *   All cards are reset to their hidden state.
+        *   The moves counter is reset to 0.
+        *   The `matchedPairs` count is reset to 0.
+        *   The `WinCelebration` component, if visible, should be hidden.
+
+*   **Test Case 6.2: Card Randomization on Restart (If Applicable)**
+    *   **Description**: If the game shuffles cards on restart, this test verifies that the card order is different from the previous game.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Record the initial order/values of cards (e.g., by their `id` and `value`).
+        *   Simulate a click on the "Restart" button.
+        *   Record the new order/values of cards.
+    *   **Assertions**:
+        *   The new card order should (with high probability) be different from the initial order. This might require multiple checks or a deterministic shuffle for testing. *Alternatively, ensure the `initialCards` generation logic (with `Math.random()`) is called again.*
+
+### 7. Instructions Modal
+
+*   **Test Case 7.1: Show Instructions**
+    *   **Description**: Verifies clicking the "Instructions" button opens the instructions modal.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Simulate a click on the "Instructions" button.
+    *   **Assertions**:
+        *   Verify the `InstructionsModal` component becomes visible.
+        *   Verify the `showInstructions` state is true.
+
+*   **Test Case 7.2: Close Instructions**
+    *   **Description**: Verifies the instructions modal can be closed.
+    *   **Actions**:
+        *   Render the `MemoryGame`.
+        *   Click "Instructions" button.
+        *   Simulate the close action on the modal (e.g., clicking its close button or overlay).
+    *   **Assertions**:
+        *   Verify the `InstructionsModal` component is no longer visible.
+        *   Verify the `showInstructions` state is false.
+```

--- a/src/components/MinesweeperGame.tests.md
+++ b/src/components/MinesweeperGame.tests.md
@@ -1,0 +1,192 @@
+```markdown
+# Minesweeper Game Unit Tests
+
+This document outlines unit tests for the `MinesweeperGame` component, located within `src/App.tsx`. These tests are designed to ensure the core functionality and game logic behave as expected. We'll assume the use of a testing framework like React Testing Library combined with Jest or Vitest.
+
+## Test Suites and Cases
+
+### 1. Initial State
+
+*   **Test Case 1.1: Grid Rendering and Dimensions**
+    *   **Description**: Verifies the grid is rendered with the correct number of cells (e.g., 8x8 = 64 cells).
+    *   **Assertions**:
+        *   Check that `gridSize * gridSize` cell elements are present in the rendered output.
+        *   Each cell should initially be in a hidden/unrevealed state.
+
+*   **Test Case 1.2: Mine Placement Count**
+    *   **Description**: Ensures the correct number of mines (`numMines`) are placed on the grid. This might require a helper function or inspecting the `grid` state directly if cell properties are not visually exposed without interaction.
+    *   **Assertions**:
+        *   Iterate through the `grid` state (or simulate gameplay to reveal all cells upon a loss) and count cells where `isMine` is true.
+        *   Verify this count equals `numMines` (e.g., 10).
+
+*   **Test Case 1.3: All Cells Initially Hidden**
+    *   **Description**: Confirms all cells are unrevealed and not flagged at the start of the game.
+    *   **Assertions**:
+        *   For each cell, verify its `isRevealed` state is false and `isFlagged` state is false.
+        *   Visually, cells should not show numbers, mines, or flags.
+
+*   **Test Case 1.4: Mine Counter Initialization**
+    *   **Description**: Checks that the mine counter correctly displays the total number of mines (or `numMines - flagsPlaced`, which is `numMines` initially).
+    *   **Assertions**:
+        *   Find the mine counter display element.
+        *   Verify its text content shows the initial number of mines (e.g., "Mines: 10").
+
+*   **Test Case 1.5: Flag Mode Off**
+    *   **Description**: Ensures flag mode is disabled by default.
+    *   **Assertions**:
+        *   Verify the `flagMode` state is false.
+        *   The "Toggle Flag" button should indicate that flag mode is OFF.
+
+### 2. Cell Interaction (Reveal Mode - Flag Mode OFF)
+
+*   **Test Case 2.1: Clicking a Mine Cell**
+    *   **Description**: Tests the game over condition when a mine is clicked.
+    *   **Actions**:
+        *   Identify a cell that contains a mine (requires knowing mine locations, possibly by pre-setting the grid state for testability or by finding one).
+        *   Simulate a click on this mine cell.
+    *   **Assertions**:
+        *   The `gameStatus` state changes to 'lost'.
+        *   A "Game Over" message is displayed.
+        *   All cells containing mines should be revealed and display a mine icon/style.
+        *   Further clicks on other cells should have no effect (game interaction disabled).
+
+*   **Test Case 2.2: Clicking a Non-Mine Cell with Adjacent Mines**
+    *   **Description**: Tests revealing a safe cell that is adjacent to one or more mines.
+    *   **Actions**:
+        *   Identify a non-mine cell that has adjacent mines.
+        *   Simulate a click on this cell.
+    *   **Assertions**:
+        *   The cell's `isRevealed` state becomes true.
+        *   The cell displays a number corresponding to `adjacentMines` count.
+        *   `gameStatus` remains 'playing'.
+
+*   **Test Case 2.3: Clicking a Non-Mine Cell with Zero Adjacent Mines (Flood Fill)**
+    *   **Description**: Tests the flood fill feature when a cell with no adjacent mines is clicked.
+    *   **Actions**:
+        *   Identify a non-mine cell with `adjacentMines === 0`.
+        *   Simulate a click on this cell.
+    *   **Assertions**:
+        *   The clicked cell is revealed (displaying nothing or '0').
+        *   All adjacent non-mine cells are recursively revealed until cells with `adjacentMines > 0` are found and revealed (but not their neighbors beyond them).
+        *   Flagged cells should not be revealed by flood fill.
+        *   `gameStatus` remains 'playing'.
+
+*   **Test Case 2.4: Clicking a Revealed Cell**
+    *   **Description**: Ensures clicking an already revealed cell does nothing.
+    *   **Actions**:
+        *   Click a safe cell to reveal it.
+        *   Click the same (now revealed) cell again.
+    *   **Assertions**:
+        *   No change in game state (`grid`, `gameStatus`, `flagsPlaced`).
+
+*   **Test Case 2.5: Clicking a Flagged Cell (in Reveal Mode)**
+    *   **Description**: Ensures a flagged cell cannot be revealed when not in flag mode.
+    *   **Actions**:
+        *   Place a flag on a cell.
+        *   Ensure flag mode is OFF.
+        *   Simulate a click on the flagged cell.
+    *   **Assertions**:
+        *   The cell remains flagged and unrevealed.
+        *   No change in game state.
+
+### 3. Flagging Logic
+
+*   **Test Case 3.1: Toggle Flag Mode Button**
+    *   **Description**: Verifies the "Toggle Flag" button correctly switches `flagMode` state.
+    *   **Actions**:
+        *   Click the "Toggle Flag" button.
+    *   **Assertions**:
+        *   `flagMode` state becomes true. Button text/style updates to "Flag Mode (ON)".
+        *   Click again. `flagMode` state becomes false. Button text/style updates to "Flag Mode (OFF)".
+
+*   **Test Case 3.2: Placing a Flag**
+    *   **Description**: Tests placing a flag on an unrevealed cell when in flag mode.
+    *   **Actions**:
+        *   Enable flag mode.
+        *   Click an unrevealed, unflagged cell.
+    *   **Assertions**:
+        *   The cell's `isFlagged` state becomes true. It displays a flag icon.
+        *   The `flagsPlaced` count increments.
+        *   The mine counter display decrements (e.g., "Mines: 9").
+
+*   **Test Case 3.3: Removing a Flag**
+    *   **Description**: Tests removing a flag from a cell when in flag mode.
+    *   **Actions**:
+        *   Enable flag mode and place a flag on a cell.
+        *   Click the same (now flagged) cell again.
+    *   **Assertions**:
+        *   The cell's `isFlagged` state becomes false. The flag icon is removed.
+        *   The `flagsPlaced` count decrements.
+        *   The mine counter display increments (e.g., back to "Mines: 10").
+
+*   **Test Case 3.4: Flagging a Revealed Cell**
+    *   **Description**: Ensures a revealed cell cannot be flagged.
+    *   **Actions**:
+        *   Reveal a safe cell.
+        *   Enable flag mode.
+        *   Click the revealed cell.
+    *   **Assertions**:
+        *   The cell remains revealed and does not become flagged.
+        *   `flagsPlaced` count and mine counter do not change.
+
+*   **Test Case 3.5: Flag Limit (Optional - if implemented)**
+    *   **Description**: Tests if the game prevents placing more flags than the total number of mines.
+    *   **Actions**:
+        *   Enable flag mode.
+        *   Place flags on `numMines` cells.
+        *   Attempt to place one more flag on another unrevealed cell.
+    *   **Assertions**:
+        *   The additional flag is not placed.
+        *   `flagsPlaced` count remains `numMines`.
+        *   Mine counter remains "Mines: 0".
+
+### 4. Win Condition
+
+*   **Test Case 4.1: All Non-Mine Cells Revealed**
+    *   **Description**: Verifies the win condition when all safe cells are revealed.
+    *   **Actions**:
+        *   Systematically reveal all non-mine cells (or setup a grid state where only non-mines are left to be revealed and reveal them).
+    *   **Assertions**:
+        *   `gameStatus` state changes to 'won'.
+        *   `WinCelebration` component is displayed.
+        *   A success message is shown.
+        *   (If implemented) Any unflagged mines are automatically flagged. `flagsPlaced` becomes `numMines`.
+        *   Game interaction (revealing/flagging) is disabled.
+
+### 5. Loss Condition (Reinforcement)
+
+*   **Test Case 5.1: Game Over on Mine Click**
+    *   **Description**: Confirms all aspects of loss condition.
+    *   **Actions**: Click a mine.
+    *   **Assertions**:
+        *   `gameStatus` is 'lost'.
+        *   "Game Over" message is displayed.
+        *   All mines on the board are revealed.
+        *   No further interaction with cells is possible.
+
+### 6. Restart Game Logic
+
+*   **Test Case 6.1: Restart Button Functionality**
+    *   **Description**: Checks if the "Restart Game" button correctly resets the game.
+    *   **Actions**:
+        *   Reveal some cells, place some flags.
+        *   Click the "Restart Game" button.
+    *   **Assertions**:
+        *   A new grid is generated (mine positions should likely differ).
+        *   All cells are reset to unrevealed and unflagged.
+        *   `gameStatus` is 'playing'.
+        *   `flagsPlaced` is 0. Mine counter is reset to `numMines`.
+        *   `flagMode` is false.
+        *   `WinCelebration` (if visible) is hidden.
+
+### 7. Instructions Modal
+
+*   **Test Case 7.1: Toggle Instructions Modal**
+    *   **Description**: Verifies the "Instructions" button shows/hides the modal.
+    *   **Actions**:
+        *   Click the "Instructions" button.
+    *   **Assertions**:
+        *   `InstructionsModal` becomes visible (`showInstructions` state is true).
+    *   **Actions (Part 2)**: Click the modal's close mechanism.
+    *   **Assertions (Part 2)**: `InstructionsModal` is hidden (`showInstructions` state is false).
+```


### PR DESCRIPTION
This commit introduces three new games to the Gaming Hub:

1.  **Memory Game**:
    *   You can flip cards to find matching pairs on a 4x4 grid.
    *   Includes move tracking and a win condition.

2.  **Hangman Game**:
    *   You can guess letters to find a hidden word.
    *   Features an SVG hangman figure that updates with incorrect guesses.
    *   Includes both text input and on-screen keyboard for guessing.

3.  **Minesweeper (Simplified) Game**:
    *   You can clear a grid while avoiding hidden mines.
    *   Features an 8x8 grid, flagging, a mine counter, and flood fill for empty areas.

All games are integrated into the main application, with navigation buttons, instruction modals, and win/loss celebrations.

Additionally, markdown files outlining unit test cases for each new game have been added:
- `src/components/MemoryGame.tests.md`
- `src/components/HangmanGame.tests.md`
- `src/components/MinesweeperGame.tests.md`