### PR TITLE
fix: Resolve TypeScript errors in test files

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vitest/globals" />
 // src/App.test.tsx
 import { render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,7 +19,7 @@ vi.mock('firebase/auth', async (importOriginal) => {
   return {
     ...actual,
     getAuth: vi.fn(() => ({})),
-    onAuthStateChanged: vi.fn((auth: any, callback: (user: any) => void) => {
+    onAuthStateChanged: vi.fn((_auth: any, callback: (user: any) => void) => { // Changed 'auth' to '_auth'
       capturedOnAuthStateChangedCallback = callback;
       return vi.fn(); // Return a mock unsubscribe function
     }),

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vitest/globals" />
 // src/contexts/AuthContext.test.tsx
 import { render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -17,7 +18,7 @@ vi.mock('firebase/auth', async (importOriginal) => {
   return {
     ...actual,
     getAuth: vi.fn(() => ({})),
-    onAuthStateChanged: vi.fn((auth: any, callback: (user: any) => void) => {
+    onAuthStateChanged: vi.fn((_auth: any, callback: (user: any) => void) => { // Changed 'auth' to '_auth'
       capturedOnAuthStateChangedCallback = callback;
       return vi.fn(); // Return a mock unsubscribe function
     }),


### PR DESCRIPTION
- Added `/// <reference types="vitest/globals" />` to the top of `AuthContext.test.tsx` and `App.test.tsx` to provide TypeScript with Vitest's global testing types (describe, test, expect, etc.).
- Renamed the unused `auth` parameter to `_auth` in the `onAuthStateChanged` mock within the `vi.mock('firebase/auth', ...)` block in both test files to resolve TS6133 (unused variable) errors.

These changes ensure the test files are correctly typed and align with TypeScript best practices, allowing the build and tests to pass.