### PR TITLE
Feat: Adjust Game Hub grid for full-width layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -402,11 +402,11 @@ body {
 /* Enhanced Game Grids */
 .game-hub-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--space-md); /* Was 1rem */
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); /* Increased min card width */
+  gap: var(--space-md);
   width: 100%;
-  max-width: 800px;
-  margin: 0 auto; /* Center the grid if its max-width is reached */
+  /* max-width: 800px; Removed for full width */
+  /* margin: 0 auto; Removed as no longer centering a max-width element */
 }
 
 .tictactoe-grid {


### PR DESCRIPTION
- Removed max-width and centering margin from .game-hub-grid in App.css to allow the game selection area to utilize the full available screen width.
- Updated grid-template-columns for .game-hub-grid to use minmax(280px, 1fr) for improved card sizing and responsiveness on wider screens.