### PR TITLE
Fix: Set GameCard overflow to visible for modal display

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -273,7 +273,7 @@ body {
   align-items: center;
   transition: all var(--transition-normal);
   position: relative;
-  overflow: hidden;
+  overflow: visible; /* Changed from hidden to allow modal visibility */
 }
 
 .game-card::before {


### PR DESCRIPTION
Changed `overflow: hidden` to `overflow: visible` on the `.game-card` style in `App.css`.

This is an immediate workaround to prevent the GameCard from clipping fixed-position modals (e.g., WinCelebration) that are rendered within its context, especially when transforms on the GameCard might create a new containing block.

The ideal long-term solution for modal rendering is to use React Portals to avoid such parent-child CSS conflicts.