### PR TITLE
Fix: Make TicTacToe cell borders visible in dark theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -340,6 +340,12 @@ body {
   transition-duration: 0.05s;
 }
 
+[data-theme="dark"] .tictactoe-cell {
+  border-color: var(--subtle-text-color); /* Ensures visibility against dark card background */
+}
+[data-theme="dark"] .tictactoe-cell:hover {
+  border-color: var(--primary-color); /* Keep hover consistent with light theme intent */
+}
 
 .tictactoe-cell:disabled {
   cursor: not-allowed;


### PR DESCRIPTION
Previously, in dark mode, the TicTacToe cell borders had the same color as the cell background, making them invisible.

This change introduces a specific CSS rule for dark theme to set the border color of TicTacToe cells to `var(--subtle-text-color)`, which provides sufficient contrast against the cell background. The hover state border color is also updated for dark theme to use `var(--primary-color)`.