### PR TITLE
Fix: Address visibility issues in Ludo, Sudoku, and Memory Game

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -126,7 +126,6 @@ body {
   /* border-color for top/left/right is transparent via inline style in App.tsx */
   border-bottom: 3px solid var(--secondary-color); /* Distinctive active indicator */
   box-shadow: 0 4px 12px color-mix(in srgb, var(--primary-color) 30%, transparent);
-  /* padding-bottom: calc(0.7em - 3px); /* Adjust if border was outside padding box. Not needed with border-box. */
 }
 .nav-button-active:hover {
   /* background-color is inline, but we can adjust other properties */
@@ -340,6 +339,12 @@ body {
   transition-duration: 0.05s;
 }
 
+[data-theme="dark"] .tictactoe-cell {
+  border-color: var(--subtle-text-color); /* Ensures visibility against dark card background */
+}
+[data-theme="dark"] .tictactoe-cell:hover {
+  border-color: var(--primary-color); /* Keep hover consistent with light theme intent */
+}
 
 .tictactoe-cell:disabled {
   cursor: not-allowed;
@@ -395,6 +400,14 @@ body {
   transform: translateY(0px);
   box-shadow: 0 1px 3px rgba(0,0,0,0.05);
   transition-duration: 0.05s;
+}
+
+[data-theme="dark"] .sudoku-cell:not(.sudoku-cell-initial):not(.sudoku-cell-selected) {
+  border: 1px solid var(--subtle-text-color); /* Explicitly set full border property */
+}
+/* Ensure hover in dark mode also has clear border if not already covered by general hover */
+[data-theme="dark"] .sudoku-cell:hover:not(:disabled):not(.sudoku-cell-initial):not(.sudoku-cell-selected) {
+  border-color: var(--primary-color); /* This should be fine as primary-color is themed for dark */
 }
 
 .sudoku-cell-initial {
@@ -576,6 +589,13 @@ body {
   background: color-mix(in srgb, var(--border-color) 40%, var(--card-background-color));
   margin: 1px;
 }
+
+[data-theme="dark"] .ludo-board-cell {
+  /* This applies to empty cells because App.tsx now sets borderColor: undefined for them.
+     Occupied cells use inline playerColors for border-color. */
+  border-color: var(--subtle-text-color);
+  /* Background is correctly handled by the base .ludo-board-cell rule using themed variables */
+}
 .ludo-board-cell-player {
   border-width: 2px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.1);
@@ -654,7 +674,6 @@ body {
 .nav-button svg, .game-button svg {
   width: 1em;
   height: 1em;
-  /* margin-right: 0.5em; Already handled by gap in span */
   vertical-align: -0.125em;
   fill: currentColor;
 }
@@ -945,6 +964,11 @@ body {
   /* Ensure these are set for 3D perspective if not already on a parent */
   perspective: 1000px;
   /* Remove direct transform from inline styles if it's for flip, let classes handle it */
+  border: 2px solid var(--border-color); /* Default border */
+}
+
+[data-theme="dark"] .memory-card {
+  border-color: var(--subtle-text-color); /* Contrast border for dark theme */
 }
 
 .memory-card-inner {
@@ -982,9 +1006,55 @@ body {
   /* Content of the front (e.g., '?') will be styled by the component */
 }
 
-.memory-card-back {
-  background-color: var(--card-bg-flipped, #e0e0e0); /* Or your card's back color */
-  color: var(--text-color); /* Or your card's back text color */
+button.memory-card .memory-card-back { /* Increased specificity */
+  background-color: var(--card-bg-flipped, #e0e0e0);
+  color: var(--text-color);
   transform: rotateY(180deg);
-  /* Content of the back (e.g., 'A', 'B') will be styled by the component */
+}
+
+/* Minesweeper cell default border */
+.minesweeper-cell {
+  border: 1px solid var(--border-color);
+}
+
+/* Minesweeper cell border in dark theme */
+[data-theme="dark"] .minesweeper-cell {
+  border-color: var(--subtle-text-color); /* Provides contrast against various cell backgrounds in dark mode */
+}
+
+/* Hangman Game Input Field */
+.game-input {
+  background-color: var(--background-color); /* Use page background for base */
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  /* Padding and font-size are handled inline in App.tsx for this specific input, but could be standardized here */
+  /* Example:
+  padding: 0.5em 0.8em;
+  font-size: 1em;
+  */
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  transition: border-color 0.2s ease-out, box-shadow 0.2s ease-out;
+}
+
+.game-input:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color) 30%, transparent);
+  outline: none;
+}
+
+[data-theme="dark"] .game-input {
+  background-color: var(--card-background-color); /* Use card background for better blend in dark game card */
+  border-color: var(--subtle-text-color); /* Contrasting border */
+}
+
+[data-theme="dark"] .game-input::placeholder {
+  color: var(--subtle-text-color);
+  opacity: 0.7;
+}
+
+/* General placeholder, could be useful if not already globally set */
+.game-input::placeholder {
+  color: var(--subtle-text-color);
+  opacity: 0.7;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -501,7 +501,7 @@ function Ludo() {
                   const i = row * 5 + col;
                   const playerHere = positions.findIndex((p, playerIdx) => playerIdx < numPlayers && p === i);
                   return (
-                    <div key={col} className={`ludo-board-cell ${playerHere !== -1 ? 'ludo-board-cell-player' : ''}`} style={{ background: playerHere !== -1 ? playerColors[playerHere] : undefined, borderColor: playerHere !== -1 ? playerColors[playerHere] : 'var(--border-color)', boxShadow: playerHere !== -1 ? `0 1px 4px ${playerColors[playerHere]}99` : undefined }} role="gridcell" aria-label={`Cell ${i+1}`}>
+                    <div key={col} className={`ludo-board-cell ${playerHere !== -1 ? 'ludo-board-cell-player' : ''}`} style={{ background: playerHere !== -1 ? playerColors[playerHere] : undefined, borderColor: playerHere !== -1 ? playerColors[playerHere] : undefined /* Let CSS handle empty cell border color */, boxShadow: playerHere !== -1 ? `0 1px 4px ${playerColors[playerHere]}99` : undefined }} role="gridcell" aria-label={`Cell ${i+1}`}>
                     </div>
                   );
                 })}
@@ -1001,7 +1001,7 @@ const MemoryGame = () => {
                 height: '80px',
                 fontSize: '2em',
                 cursor: 'pointer',
-                border: '2px solid var(--border-color)',
+                /* border: '2px solid var(--border-color)', // Moved to CSS */
                 borderRadius: '8px',
                 padding: 0, // Remove padding for inner content to fill
                 // background, color, transform are now handled by CSS classes
@@ -1444,7 +1444,7 @@ const MinesweeperGame = () => {
                   alignItems: 'center',
                   justifyContent: 'center',
                   cursor: 'pointer',
-                  border: '1px solid var(--border-color)',
+                  /* border: '1px solid var(--border-color)', // Moved to CSS */
                   borderRadius: '4px',
                   backgroundColor: cell.isRevealed
                     ? (cell.isMine ? 'var(--error-color)' : 'var(--disabled-bg-color)')

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,9 @@
   --subtle-text-color: #7F8C8D; /* Lighter gray for less important text */
   --disabled-bg-color: #BDC3C7;
   --disabled-text-color: #7F8C8D;
+  --button-bg-color: var(--card-background-color); /* For elements like memory card front */
+  --card-bg-flipped: #e0e0e0; /* Memory card back */
+  --warning-bg-color: #FFD700; /* Gold - for things like flagged cells */
 
   font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -40,6 +43,9 @@
   --subtle-text-color: #A0AEC0; /* Medium Gray */
   --disabled-bg-color: #4A5568;
   --disabled-text-color: #A0AEC0;
+  --button-bg-color: var(--card-background-color); /* For elements like memory card front */
+  --card-bg-flipped: #374151; /* Memory card back - a bit lighter than card bg */
+  --warning-bg-color: var(--secondary-color); /* Lighter Orange/Yellow for dark mode warnings */
 
   color-scheme: dark;
 }


### PR DESCRIPTION
This commit resolves several UI visibility problems:

1.  **Ludo (Dark Theme):** Empty cell borders were not visible due to inline styles overriding the CSS theme. Changed inline styles in `App.tsx` for Ludo to allow CSS to control empty cell border colors. Adjusted the dark theme CSS rule in `src/App.css` for `.ludo-board-cell` to correctly apply `var(--subtle-text-color)` for borders.

2.  **Sudoku (Dark Theme):** Cell borders were reported as not visible. Modified the dark theme CSS rule in `src/App.css` for `.sudoku-cell:not(.sudoku-cell-initial):not(.sudoku-cell-selected)` to explicitly set the full `border: 1px solid var(--subtle-text-color);` to ensure visibility.

3.  **Memory Game (Light Theme):** Characters on flipped cards were not visible. Increased the specificity of the CSS rule for `.memory-card-back` in `src/App.css` to `button.memory-card .memory-card-back` to ensure `color: var(--text-color);` (dark gray in light theme) is applied, making characters visible against the light gray card back.