### PR TITLE
Fix: Further UI visibility improvements for dark and light themes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -988,7 +988,7 @@ body {
 }
 
 .memory-card-front,
-.memory-card-back {
+button.memory-card .memory-card-back { /* Increased specificity for .memory-card-back */
   position: absolute;
   width: 100%;
   height: 100%;
@@ -1001,16 +1001,25 @@ body {
 }
 
 .memory-card-front {
-  background-color: var(--button-bg-color); /* Or your card's front color */
+  background-color: var(--button-bg-color);
   color: transparent; /* Hide the '?' if it was text, or style it as card front */
-  /* Content of the front (e.g., '?') will be styled by the component */
 }
 
-button.memory-card .memory-card-back { /* Increased specificity */
-  background-color: var(--card-bg-flipped, #e0e0e0);
-  color: var(--text-color);
+/* Specific text color for memory card back in light theme */
+:root button.memory-card .memory-card-back {
+  color: #000000; /* Pure black for light theme card back text */
+}
+
+/* Specific text color for memory card back in dark theme */
+[data-theme="dark"] button.memory-card .memory-card-back {
+  color: var(--text-color); /* Uses dark theme's light text color */
+}
+
+button.memory-card .memory-card-back { /* Base styles for back */
+  background-color: var(--card-bg-flipped);
   transform: rotateY(180deg);
 }
+
 
 /* Minesweeper cell default border */
 .minesweeper-cell {
@@ -1022,17 +1031,27 @@ button.memory-card .memory-card-back { /* Increased specificity */
   border-color: var(--subtle-text-color); /* Provides contrast against various cell backgrounds in dark mode */
 }
 
+/* Minesweeper symbol colors (flag, mine) - overrides component inline style for color */
+:root .minesweeper-cell.flagged {
+  color: var(--text-color); /* Dark text for flag on gold background in light theme */
+}
+[data-theme="dark"] .minesweeper-cell.flagged {
+  color: #000000; /* Black text for flag on light orange background in dark theme */
+}
+:root .minesweeper-cell.mine.revealed {
+  color: #000000; /* Black mine symbol on red background in light theme */
+}
+[data-theme="dark"] .minesweeper-cell.mine.revealed {
+  color: #000000; /* Black mine symbol on light red background in dark theme */
+}
+
+
 /* Hangman Game Input Field */
 .game-input {
   background-color: var(--background-color); /* Use page background for base */
   color: var(--text-color);
   border: 1px solid var(--border-color);
   border-radius: 6px;
-  /* Padding and font-size are handled inline in App.tsx for this specific input, but could be standardized here */
-  /* Example:
-  padding: 0.5em 0.8em;
-  font-size: 1em;
-  */
   box-shadow: 0 1px 3px rgba(0,0,0,0.05);
   transition: border-color 0.2s ease-out, box-shadow 0.2s ease-out;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,16 @@
   --card-bg-flipped: #e0e0e0; /* Memory card back */
   --warning-bg-color: #FFD700; /* Gold - for things like flagged cells */
 
+  /* Minesweeper Number Colors - Light Theme */
+  --mine-count-1: #0000FF; /* Blue */
+  --mine-count-2: #008000; /* Green */
+  --mine-count-3: #FF0000; /* Red */
+  --mine-count-4: #000080; /* Navy */
+  --mine-count-5: #800000; /* Maroon */
+  --mine-count-6: #008080; /* Teal */
+  --mine-count-7: #000000; /* Black */
+  --mine-count-8: #808080; /* Gray */
+
   font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -39,13 +49,23 @@
   --card-background-color: #2D3748; /* Slightly lighter than main bg, or same */
   --error-color: #FC8181; /* Lighter Red */
   --success-color: #68D391; /* Lighter Green */
-  --button-text-color: #1A202C; /* Dark text for light primary/secondary buttons if they stay light, else #FFFFFF */
+  --button-text-color: #FFFFFF; /* White text for buttons in dark mode */
   --subtle-text-color: #A0AEC0; /* Medium Gray */
   --disabled-bg-color: #4A5568;
   --disabled-text-color: #A0AEC0;
   --button-bg-color: var(--card-background-color); /* For elements like memory card front */
   --card-bg-flipped: #374151; /* Memory card back - a bit lighter than card bg */
   --warning-bg-color: var(--secondary-color); /* Lighter Orange/Yellow for dark mode warnings */
+
+  /* Minesweeper Number Colors - Dark Theme */
+  --mine-count-1: #ADD8E6; /* Light Blue */
+  --mine-count-2: #90EE90; /* Light Green */
+  --mine-count-3: #FFB6C1; /* Light Pink/Red */
+  --mine-count-4: #B19CD9; /* Light Purple/Navy */
+  --mine-count-5: #F5DEB3; /* Wheat/Light Brown */
+  --mine-count-6: #AFEEEE; /* Pale Turquoise/Cyan */
+  --mine-count-7: #D3D3D3; /* Light Gray (for black in light) */
+  --mine-count-8: #A9A9A9; /* Dark Gray (for gray in light, needs to be lighter than cell bg) */
 
   color-scheme: dark;
 }


### PR DESCRIPTION
This commit addresses several reported visibility issues:

1.  **Dark Mode Button Text:** Changed `--button-text-color` in the dark theme to `#FFFFFF` (white) in `src/index.css` to ensure button text is visible against various button backgrounds.

2.  **Memory Game (Light Theme):** Ensured characters on flipped cards are visible by setting their text color to black explicitly for the light theme in `src/App.css` using a more specific selector for `.memory-card-back`.

3.  **Minesweeper (Numbers & Symbols):**
    *   Defined `--mine-count-X` (1-8) variables for both light (`:root`) and dark (`[data-theme="dark"]`) themes in `src/index.css` to provide appropriate, contrasting colors for numbers in revealed cells.
    *   Added CSS rules in `src/App.css` to explicitly set the color of flag (🚩) and mine (💣) symbols for better visibility in both light and dark themes, overriding potentially problematic inline styles.

4.  **Hangman (Light Theme):** No code changes were made in this iteration as previous analysis indicated existing styles should provide adequate contrast. Further monitoring or specific feedback may be needed if issues persist here.