### PR TITLE
Fix: Update chat icon to a speech bubble design

### DIFF
--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import './Chatbot.css';
 
-// A simple chat bubble icon (SVG)
+// Updated Chat Bubble Icon (Speech Bubble with Tail)
 const ChatIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-    <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"/>
+    <path d="M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4V4c0-1.1-.9-2-2-2z"/>
   </svg>
 );
 


### PR DESCRIPTION
Replaced the previous chat icon SVG in Chatbot.tsx with a new SVG representing a more standard speech bubble with a tail. This icon uses `fill="currentColor"` and is styled via CSS to use `var(--button-text-color)`, ensuring it adapts correctly to light and dark themes.